### PR TITLE
Fix problem with files without "stat" ('isSymbolicLink' of undefined)

### DIFF
--- a/lib/zip/index.js
+++ b/lib/zip/index.js
@@ -20,7 +20,7 @@ function zip(zipPath) {
 
     var path = file.relative.replace(/\\/g, '/');
 
-    if (file.stat.isSymbolicLink && file.stat.isSymbolicLink()) {
+    if (stat.isSymbolicLink && stat.isSymbolicLink()) {
       zip.addBuffer(new Buffer(file.symlink), path, opts);
     } else if (file.isDirectory()) {
       zip.addEmptyDirectory(path, opts);
@@ -29,7 +29,7 @@ function zip(zipPath) {
     } else if (file.isStream()) {
       zip.addReadStream(file.contents, path, opts);
     }
-    
+
     cb();
   }, function(cb) {
     stream.push(new File({path: zipPath, contents: zip.outputStream}));

--- a/test/tests.js
+++ b/test/tests.js
@@ -104,4 +104,17 @@ describe('gulp-vinyl-zip', function () {
 					}));
 			});
 	});
+
+	it('dest should not assume files have `stat`', function (cb) {
+		var dest = temp.openSync('gulp-vinyl-zip-test').path;
+
+		lib.src(path.join(__dirname, 'assets', 'archive.zip'))
+			.pipe(through.obj(function(chunk, enc, cb) {
+				delete chunk.stat;
+				this.push(chunk);
+				cb();
+			}))
+			.pipe(lib.dest(dest))
+			.on('end', cb);
+	});
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -81,15 +81,15 @@ describe('gulp-vinyl-zip', function () {
 					.pipe(through.obj(function (file, enc, cb) {
 						count++;
 
-						if (stats[file.path].atime || file.stat.atime) {
+						if (stats[file.path].atime.valueOf() || file.stat.atime.valueOf()) {
 							assert.equal(stats[file.path].atime.getTime(), file.stat.atime.getTime());
 						}
 
-						if (stats[file.path].ctime || file.stat.ctime) {
+						if (stats[file.path].ctime.valueOf() || file.stat.ctime.valueOf()) {
 							assert.equal(stats[file.path].ctime.getTime(), file.stat.ctime.getTime());
 						}
 
-						if (stats[file.path].mtime || file.stat.mtime) {
+						if (stats[file.path].mtime.valueOf() || file.stat.mtime.valueOf()) {
 							assert.equal(stats[file.path].mtime.getTime(), file.stat.mtime.getTime());
 						}
 


### PR DESCRIPTION
I ran into a problem with `zip.dest()` of files without `stat`, and it seems to be simple to fix. Basically, change `file.stat.isSymbolicLink` to `stat.isSymbolicLink` in `lib/zip/index.js`.
