### PR TITLE
Update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/lib/vinyl-zip.js
+++ b/lib/vinyl-zip.js
@@ -1,14 +1,11 @@
 'use strict';
 
 var File = require('vinyl');
-var util = require('util');
 
-function ZipFile(file) {
-	File.call(this, file);
-	
-	this.symlink = file.symlink || null;
+class ZipFile extends File {
+	constructor(file) {
+	  super(file);
+	}
 }
-
-util.inherits(ZipFile, File);
 
 module.exports = ZipFile;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-vinyl-zip",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Streaming vinyl adapter for zip archives",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "homepage": "https://github.com/joaomoreno/gulp-vinyl-zip",
   "dependencies": {
     "event-stream": "^3.3.1",
-    "queue": "^3.0.10",
-    "through2": "^0.6.3",
-    "vinyl": "^0.4.6",
+    "queue": "^4.2.1",
+    "through2": "^2.0.3",
+    "vinyl": "^2.0.2",
     "vinyl-fs": "^2.0.0",
     "yauzl": "^2.2.1",
     "yazl": "^2.2.1"


### PR DESCRIPTION
Hello João :smile: 

I discovered your lib and it's exactly what I need for my project. In my code, I'm using some of the new properties of the recent versions of `vinyl` files like `basename`. The pb I have is that they're not supported in version `0.4.6`.

First, I started a small/simple PR to update all outdated deps and it seems the new version of `vinyl` doesn't like the way `util.inherits()` works. It's missing the `constructor` property.

I'm proposing a v2.0.0 dropping support for 0.12 and using the `class` keyword instead of `util.inherits()`.

WDYT? It's just a proposition, I would understand if such a version bump is too much in your opinion.