### PR TITLE
Option to not create an empty zip

### DIFF
--- a/lib/zip/index.js
+++ b/lib/zip/index.js
@@ -10,6 +10,7 @@ function zip(zipPath, options) {
   options = options || {};
 
   var zip = new yazl.ZipFile();
+  var isEmpty = true;
 
   var stream = through.obj(function(file, enc, cb) {
     var stat = file.stat || {};
@@ -39,8 +40,13 @@ function zip(zipPath, options) {
       zip.addReadStream(file.contents, path, opts);
     }
 
+    isEmpty = false;
     cb();
   }, function(cb) {
+    if (isEmpty && options.unlessEmpty) {
+      return cb();
+    }
+
     stream.push(new File({path: zipPath, contents: zip.outputStream}));
     zip.end(function() {
       cb();


### PR DESCRIPTION
This adds a new boolean option `unlessEmpty`. When `true` and nothing has been received for compression, no zip will be emitted at the end. Existing behaviour without the option should be unchanged.

I was attempting to combine this plugin with gulp-newer to only regenerate a zip if the contents had changed, but found the zip was always created and overwritten even if it was given no files. This PR should enable a new use case without adversely affecting existing users.