### PR TITLE
fix Buffer deprecation warnings

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -48,7 +48,7 @@ function toStream(zip) {
 
 		if (stat.isFile()) {
 			if (entry.uncompressedSize === 0) {
-				file.contents = new Buffer(0);
+				file.contents = Buffer.alloc(0);
 				result.emit('data', new File(file));
 
 			} else {

--- a/lib/zip/index.js
+++ b/lib/zip/index.js
@@ -25,7 +25,7 @@ function zip(zipPath, options) {
     var path = file.relative.replace(/\\/g, '/');
 
     if (stat.isSymbolicLink && stat.isSymbolicLink()) {
-      zip.addBuffer(new Buffer(file.symlink), path, opts);
+      zip.addBuffer(Buffer.from(file.symlink), path, opts);
     } else if (file.isDirectory()) {
       // In Windows, directories have a 666 permissions. This doesn't go well
       // on OS X and Linux, where directories are expected to be 755.


### PR DESCRIPTION
- use Buffer.alloc and Buffer.from instead of new Buffer